### PR TITLE
Clarification to H2H for Lockpick angle mod

### DIFF
--- a/gameplay.html
+++ b/gameplay.html
@@ -324,6 +324,7 @@ SOFTWARE.
                         <li>Optional Files - Hand to Hand - Locksmith Addon (select the name that matches the file on Nexus when the installation prompt comes up)</li>
                         <li>Optional Files - Hand to Hand - Trainers and Skill Books Addon (select the name that matches the file on Nexus when the installation prompt comes up)</li>
                     </ul>Addon for Adamant - A Perk Overhaul that merges Lockpicking and Pickpocketing into a single skill and adds a new perk tree for Hand to Hand combat.</p>
+                    <blockquote>The Locksmith Addon will make a change to the Remember Lockpick Angle mod so it now requires a perk before the game will remember lockpick position.</blockquote>
                 </div>
                 <!-- Sensible Bribes -->
                 <div class="section">


### PR DESCRIPTION
Adds clarification to the H2H mod that explains it makes a perk requirement to use the Lockpick Angle Mod functionality.